### PR TITLE
Add decompilation changes caused by renamed bundle file

### DIFF
--- a/scripts/entity_system/systems/behaviour/nodes/generated/bt_selector_chaos_exalted_sorcerer_drachenfels.lua
+++ b/scripts/entity_system/systems/behaviour/nodes/generated/bt_selector_chaos_exalted_sorcerer_drachenfels.lua
@@ -62,49 +62,7 @@ BTSelector_chaos_exalted_sorcerer_drachenfels.run = function (self, unit, blackb
 		self:set_running_child(unit, blackboard, t, nil, "failed")
 	end
 
-	local node_falling = children[3]
-	local condition_result = blackboard.is_falling or blackboard.fall_state ~= nil
-
-	if condition_result then
-		self:set_running_child(unit, blackboard, t, node_falling, "aborted")
-
-		local result, evaluate = node_falling:run(unit, blackboard, t, dt)
-
-		if result ~= "running" then
-			self:set_running_child(unit, blackboard, t, nil, result)
-		end
-
-		if result ~= "failed" then
-			return result, evaluate
-		end
-	elseif node_falling == child_running then
-		self:set_running_child(unit, blackboard, t, nil, "failed")
-	end
-
-	local node_stagger = children[4]
-	local condition_result = nil
-
-	if blackboard.stagger then
-		condition_result = not blackboard.stagger_prohibited
-	end
-
-	if condition_result then
-		self:set_running_child(unit, blackboard, t, node_stagger, "aborted")
-
-		local result, evaluate = node_stagger:run(unit, blackboard, t, dt)
-
-		if result ~= "running" then
-			self:set_running_child(unit, blackboard, t, nil, result)
-		end
-
-		if result ~= "failed" then
-			return result, evaluate
-		end
-	elseif node_stagger == child_running then
-		self:set_running_child(unit, blackboard, t, nil, "failed")
-	end
-
-	local node_smartobject = children[5]
+	local node_smartobject = children[3]
 	local condition_result = nil
 	local next_smart_object_data = blackboard.next_smart_object_data
 	local smartobject_is_next = next_smart_object_data.next_smart_object_id ~= nil
@@ -145,7 +103,7 @@ BTSelector_chaos_exalted_sorcerer_drachenfels.run = function (self, unit, blackb
 		self:set_running_child(unit, blackboard, t, nil, "failed")
 	end
 
-	local node_defensive_mode = children[6]
+	local node_defensive_mode = children[4]
 	local condition_result = blackboard.mode == "defensive" and not blackboard.is_summoning
 
 	if condition_result then
@@ -164,7 +122,7 @@ BTSelector_chaos_exalted_sorcerer_drachenfels.run = function (self, unit, blackb
 		self:set_running_child(unit, blackboard, t, nil, "failed")
 	end
 
-	local node_has_target = children[7]
+	local node_has_target = children[5]
 	local condition_result = unit_alive(blackboard.target_unit)
 
 	if condition_result then
@@ -183,7 +141,7 @@ BTSelector_chaos_exalted_sorcerer_drachenfels.run = function (self, unit, blackb
 		self:set_running_child(unit, blackboard, t, nil, "failed")
 	end
 
-	local node_idle = children[8]
+	local node_idle = children[6]
 
 	self:set_running_child(unit, blackboard, t, node_idle, "aborted")
 

--- a/scripts/settings/breeds/breed_chaos_dummy_exalted_sorcerer_drachenfels.lua
+++ b/scripts/settings/breeds/breed_chaos_dummy_exalted_sorcerer_drachenfels.lua
@@ -1,15 +1,16 @@
 local breed_data = {
-	boss_staggers = true,
-	perception = "perception_no_seeing",
-	has_inventory = true,
-	animation_sync_rpc = "rpc_sync_anim_state_8",
-	not_bot_target = true,
+	detection_radius = 50,
 	walk_speed = 0.65,
+	has_inventory = true,
+	perception = "perception_all_seeing_boss",
+	not_bot_target = true,
+	animation_sync_rpc = "rpc_sync_anim_state_8",
 	run_speed = 0.65,
-	target_selection = "pick_no_targets",
+	target_selection = "pick_boss_sorcerer_target",
 	exchange_order = 1,
 	armored_on_no_damage = true,
-	death_reaction = "ai_default",
+	boss_staggers = true,
+	poison_resistance = 100,
 	combat_music_state = "no_boss",
 	debug_spawn_category = "Misc",
 	bone_lod_level = 0,
@@ -22,11 +23,12 @@ local breed_data = {
 	hit_mass_count = 8,
 	race = "chaos",
 	no_autoaim = true,
-	poison_resistance = 100,
+	death_reaction = "ai_default",
 	armor_category = 3,
 	far_off_despawn_immunity = true,
+	is_of_interest_func = "is_of_interest_boss_sorcerer",
 	stagger_immune = true,
-	behavior = "dummy_sorcerer",
+	behavior = "dummy_exalted_sorcerer_drachenfels",
 	base_unit = "units/beings/enemies/chaos_dummy_sorcerer_boss_drachenfels/chr_chaos_dummy_sorcerer_boss_drachenfels",
 	threat_value = 8,
 	max_health = {
@@ -151,14 +153,106 @@ local breed_data = {
 				"h_afro"
 			}
 		}
-	},
-	run_on_spawn = AiBreedSnippets.on_dummy_sorcerer_spawn
+	}
 }
 Breeds.chaos_dummy_exalted_sorcerer_drachenfels = table.create_copy(Breeds.chaos_dummy_exalted_sorcerer_drachenfels, breed_data)
 local action_data = {
 	idle = {
-		idle_animation = {
-			"attack_cast_spell_loop"
+		no_anim = true
+	},
+	spawn = {
+		duration = 3,
+		animation = "float_idle_nostaff"
+	},
+	defensive_seeking_bomb = {
+		create_nav_tag_volume = true,
+		radius = 2,
+		cast_time = 0,
+		initial_radius = 1.2,
+		nav_tag_volume_layer = "bot_poison_wind",
+		damage_type = "poison",
+		duration = 8,
+		face_target_while_casting = true,
+		volleys = 1,
+		volley_delay = 0.3,
+		action_weight = 1,
+		aoe_dot_damage_interval = 1,
+		considerations = UtilityConsiderations.dummy_defensive_seeking_bomb,
+		spell_data = {
+			name = "seeking_bomb_missile",
+			explosion_template_name = "chaos_slow_bomb_missile_new",
+			magic_missile = true,
+			magic_missile_speed = 2.5,
+			true_flight_template_name = "sorcerer_slow_bomb_missile",
+			projectile_unit_name = "units/weapons/projectile/insect_swarm_missile_drachenfels/insect_swarm_missile_drachenfels_01",
+			range = 40,
+			life_time = 15,
+			throw_pos = Vector3Box(),
+			target_direction = Vector3Box(),
+			projectile_size = {
+				3,
+				3,
+				3
+			}
+		},
+		aoe_init_damage = {
+			{
+				0,
+				1,
+				0
+			},
+			{
+				0,
+				1,
+				0
+			},
+			{
+				5,
+				1,
+				0
+			},
+			{
+				7,
+				1,
+				0
+			},
+			{
+				10,
+				1,
+				0
+			}
+		},
+		aoe_dot_damage = {
+			{
+				2,
+				0,
+				0
+			},
+			{
+				4,
+				0,
+				0
+			},
+			{
+				6,
+				0,
+				0
+			},
+			{
+				8,
+				0,
+				0
+			},
+			{
+				15,
+				0,
+				0
+			}
+		},
+		missile_spawn_offset = {
+			0.1281,
+			1.1719,
+			1.3749
 		}
 	}
 }


### PR DESCRIPTION
There's two versions of bt_selector_chaos_exalted_sorcerer_drachenfels.lua and breed_chaos_dummy_exalted_sorcerer_drachenfels.lua in the game bundles.

One set is in 4781bad4b7d3a395.patch_026, and the other is in 9669843dd479648f. This is likely because the developers moved the files to a new package in a patch after 026. In previous decompilations, all base bundles would be decompiled before patch bundles. In the new decompilations, the ordering in bundle_database.data is respected.